### PR TITLE
Switch RobotController to ODrive command publishing

### DIFF
--- a/src/industrial_robot_jazzy/CMakeLists.txt
+++ b/src/industrial_robot_jazzy/CMakeLists.txt
@@ -9,9 +9,6 @@ endif()
 find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(std_msgs REQUIRED)
-find_package(sensor_msgs REQUIRED)
-find_package(geometry_msgs REQUIRED)
-find_package(trajectory_msgs REQUIRED)
 
 # Create executable
 add_executable(robot_controller 
@@ -19,12 +16,9 @@ add_executable(robot_controller
 )
 
 # Specify dependencies
-ament_target_dependencies(robot_controller 
-  rclcpp 
-  std_msgs 
-  sensor_msgs 
-  geometry_msgs
-  trajectory_msgs
+ament_target_dependencies(robot_controller
+  rclcpp
+  std_msgs
 )
 
 # Install executable

--- a/src/industrial_robot_jazzy/package.xml
+++ b/src/industrial_robot_jazzy/package.xml
@@ -11,9 +11,6 @@
 
   <depend>rclcpp</depend>
   <depend>std_msgs</depend>
-  <depend>sensor_msgs</depend>
-  <depend>geometry_msgs</depend>
-  <depend>trajectory_msgs</depend>
   <depend>robot_state_publisher</depend>
   <depend>joint_state_publisher</depend>
   <depend>joint_state_publisher_gui</depend>

--- a/src/industrial_robot_jazzy/src/robot_controller.cpp
+++ b/src/industrial_robot_jazzy/src/robot_controller.cpp
@@ -1,86 +1,45 @@
 #include <rclcpp/rclcpp.hpp>
 #include <std_msgs/msg/float64_multi_array.hpp>
-#include <sensor_msgs/msg/joint_state.hpp>
-#include <trajectory_msgs/msg/joint_trajectory.hpp>
-#include <trajectory_msgs/msg/joint_trajectory_point.hpp>
 #include <chrono>
 #include <memory>
-#include <cmath>
 
 class RobotController : public rclcpp::Node
 {
 public:
     RobotController() : Node("robot_controller")
     {
-        // Publishers
-        position_cmd_pub_ = this->create_publisher<std_msgs::msg::Float64MultiArray>(
-            "/position_controller/commands", 10);
-            
-        trajectory_pub_ = this->create_publisher<trajectory_msgs::msg::JointTrajectory>(
-            "/trajectory_controller/joint_trajectory", 10);
-            
-        // Subscribers
-        joint_state_sub_ = this->create_subscription<sensor_msgs::msg::JointState>(
-            "/joint_states", 10, 
-            std::bind(&RobotController::jointStateCallback, this, std::placeholders::_1));
-            
+        // Publisher for ODrive commands
+        odrive_cmd_pub_ = this->create_publisher<std_msgs::msg::Float64MultiArray>(
+            "/odrive/commands", 10);
+
         // Timer
         timer_ = this->create_wall_timer(
             std::chrono::seconds(3),
-            std::bind(&RobotController::sendTrajectory, this));
+            std::bind(&RobotController::sendOdriveCommand, this));
             
         RCLCPP_INFO(this->get_logger(), "Robot Controller started for ROS2 Jazzy");
     }
     
 private:
-    void jointStateCallback(const sensor_msgs::msg::JointState::SharedPtr msg)
-    {
-        current_positions_ = msg->position;
-        // RCLCPP_INFO(this->get_logger(), "Current joint positions received");
-    }
-    
-    void sendSimplePositionCommand()
+    void sendOdriveCommand()
     {
         auto cmd_msg = std_msgs::msg::Float64MultiArray();
-        static double angle = 0.0;
-        angle += 0.1;
-        if (angle > 3.14) angle = -3.14;
-        
-        cmd_msg.data = {angle, std::sin(angle * 0.5)};
-        position_cmd_pub_->publish(cmd_msg);
-        
-        RCLCPP_INFO(this->get_logger(), "Position command sent: [%.2f, %.2f]", angle, std::sin(angle * 0.5));
+        static bool toggle = false;
+        if (toggle) {
+            cmd_msg.data = {0.5, 0.3};
+        } else {
+            cmd_msg.data = {-0.5, -0.3};
+        }
+        toggle = !toggle;
+
+        odrive_cmd_pub_->publish(cmd_msg);
+
+        RCLCPP_INFO(this->get_logger(), "ODrive command sent: [%.2f, %.2f]",
+                    cmd_msg.data[0], cmd_msg.data[1]);
     }
-    
-    void sendTrajectory()
-    {
-        auto trajectory_msg = trajectory_msgs::msg::JointTrajectory();
-        trajectory_msg.header.stamp = this->now();
-        trajectory_msg.joint_names = {"joint1", "joint2"};
-        
-        // Punkt 1
-        trajectory_msgs::msg::JointTrajectoryPoint point1;
-        point1.positions = {0.5, 0.3};
-        point1.velocities = {0.0, 0.0};
-        point1.time_from_start = rclcpp::Duration::from_seconds(2.0);
-        
-        // Punkt 2
-        trajectory_msgs::msg::JointTrajectoryPoint point2;
-        point2.positions = {-0.5, -0.3};
-        point2.velocities = {0.0, 0.0};
-        point2.time_from_start = rclcpp::Duration::from_seconds(4.0);
-        
-        trajectory_msg.points = {point1, point2};
-        trajectory_pub_->publish(trajectory_msg);
-        
-        RCLCPP_INFO(this->get_logger(), "Trajectory sent to robot");
-    }
-    
-    rclcpp::Publisher<std_msgs::msg::Float64MultiArray>::SharedPtr position_cmd_pub_;
-    rclcpp::Publisher<trajectory_msgs::msg::JointTrajectory>::SharedPtr trajectory_pub_;
-    rclcpp::Subscription<sensor_msgs::msg::JointState>::SharedPtr joint_state_sub_;
+
+    rclcpp::Publisher<std_msgs::msg::Float64MultiArray>::SharedPtr odrive_cmd_pub_;
     rclcpp::TimerBase::SharedPtr timer_;
-    std::vector<double> current_positions_;
 };
 
 int main(int argc, char** argv)


### PR DESCRIPTION
## Summary
- publish ODrive commands on `/odrive/commands`
- streamline dependencies and remove unused code

## Testing
- `colcon build --packages-select industrial_robot_jazzy` *(fails: Could not find package configuration file provided by "ament_cmake")*


------
https://chatgpt.com/codex/tasks/task_e_689dd6333524832fa789be64848d6736