### PR TITLE
Add ODrive CAN node to launch

### DIFF
--- a/src/industrial_robot_jazzy/launch/simple_robot.launch.py
+++ b/src/industrial_robot_jazzy/launch/simple_robot.launch.py
@@ -1,6 +1,7 @@
 import os, xacro
 from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
+from launch.actions import TimerAction
 from launch_ros.actions import Node
 from launch.substitutions import PathJoinSubstitution
 from launch_ros.substitutions import FindPackageShare
@@ -11,10 +12,22 @@ def generate_launch_description():
     doc = xacro.process_file(xacro_file)
     robot_description = {"robot_description": doc.toxml()}
 
+    odrive = Node(
+        package="odrive_can",
+        executable="odrive_can_node",
+        name="odrive_can_node",
+        parameters=[
+            {"can_interface": "can0"},
+            {"axis_id": 0},
+            {"use_sim_time": False},
+        ],
+        output="screen",
+    )
+
     rsp = Node(
         package="robot_state_publisher",
         executable="robot_state_publisher",
-        parameters=[robot_description],
+        parameters=[robot_description, {"use_sim_time": False}],
         output="both",
     )
 
@@ -22,6 +35,7 @@ def generate_launch_description():
         package="joint_state_publisher_gui",
         executable="joint_state_publisher_gui",
         name="joint_state_publisher_gui",
+        parameters=[{"use_sim_time": False}],
     )
 
     rviz_config = PathJoinSubstitution([FindPackageShare("industrial_robot_jazzy"), "rviz", "view.rviz"])
@@ -30,6 +44,12 @@ def generate_launch_description():
         executable="rviz2",
         arguments=["-d", rviz_config],
         output="screen",
+        parameters=[{"use_sim_time": False}],
     )
 
-    return LaunchDescription([rsp, jsp, rviz])
+    delayed_nodes = TimerAction(
+        period=2.0,
+        actions=[rsp, jsp, rviz],
+    )
+
+    return LaunchDescription([odrive, delayed_nodes])

--- a/src/industrial_robot_jazzy/package.xml
+++ b/src/industrial_robot_jazzy/package.xml
@@ -22,6 +22,7 @@
   <depend>ros2_control</depend>
   <depend>ros2_controllers</depend>
   <depend>gazebo_ros2_control</depend>
+  <exec_depend>odrive_can</exec_depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>


### PR DESCRIPTION
## Summary
- add ODrive CAN node with interface and axis parameters
- delay robot state publisher until ODrive is ready and use real time
- declare runtime dependency on odrive_can

## Testing
- `python3 -m colcon build --packages-select industrial_robot_jazzy --build-base build_colcon --install-base install_colcon` *(fails: Could not find ament_cmake)*
- `python3 -m colcon test --packages-select industrial_robot_jazzy --build-base build_colcon --install-base install_colcon`


------
https://chatgpt.com/codex/tasks/task_e_689dd632a380832fb8206c73a69f440e