### PR TITLE
Add CAN dependencies and ODrive CAN node

### DIFF
--- a/src/industrial_robot_jazzy/CMakeLists.txt
+++ b/src/industrial_robot_jazzy/CMakeLists.txt
@@ -12,23 +12,37 @@ find_package(std_msgs REQUIRED)
 find_package(sensor_msgs REQUIRED)
 find_package(geometry_msgs REQUIRED)
 find_package(trajectory_msgs REQUIRED)
+find_package(can_msgs REQUIRED)
 
 # Create executable
-add_executable(robot_controller 
+add_executable(robot_controller
   src/robot_controller.cpp
 )
 
+add_executable(odrive_can_node
+  src/odrive_can_node.cpp
+)
+
 # Specify dependencies
-ament_target_dependencies(robot_controller 
-  rclcpp 
-  std_msgs 
-  sensor_msgs 
+ament_target_dependencies(robot_controller
+  rclcpp
+  std_msgs
+  sensor_msgs
   geometry_msgs
   trajectory_msgs
 )
 
+ament_target_dependencies(odrive_can_node
+  rclcpp
+  can_msgs
+)
+
 # Install executable
 install(TARGETS robot_controller
+  DESTINATION lib/${PROJECT_NAME}
+)
+
+install(TARGETS odrive_can_node
   DESTINATION lib/${PROJECT_NAME}
 )
 

--- a/src/industrial_robot_jazzy/package.xml
+++ b/src/industrial_robot_jazzy/package.xml
@@ -22,6 +22,8 @@
   <depend>ros2_control</depend>
   <depend>ros2_controllers</depend>
   <depend>gazebo_ros2_control</depend>
+  <depend>can_msgs</depend>
+  <depend>socketcan_bridge</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/src/industrial_robot_jazzy/src/odrive_can_node.cpp
+++ b/src/industrial_robot_jazzy/src/odrive_can_node.cpp
@@ -1,0 +1,31 @@
+#include <rclcpp/rclcpp.hpp>
+#include <can_msgs/msg/frame.hpp>
+
+class OdriveCANNode : public rclcpp::Node
+{
+public:
+  OdriveCANNode() : Node("odrive_can_node")
+  {
+    publisher_ = this->create_publisher<can_msgs::msg::Frame>("can_tx", 10);
+    subscription_ = this->create_subscription<can_msgs::msg::Frame>(
+      "can_rx", 10,
+      std::bind(&OdriveCANNode::on_frame, this, std::placeholders::_1));
+  }
+
+private:
+  void on_frame(const can_msgs::msg::Frame::SharedPtr msg)
+  {
+    (void)msg;
+  }
+
+  rclcpp::Publisher<can_msgs::msg::Frame>::SharedPtr publisher_;
+  rclcpp::Subscription<can_msgs::msg::Frame>::SharedPtr subscription_;
+};
+
+int main(int argc, char **argv)
+{
+  rclcpp::init(argc, argv);
+  rclcpp::spin(std::make_shared<OdriveCANNode>());
+  rclcpp::shutdown();
+  return 0;
+}


### PR DESCRIPTION
## Summary
- add `can_msgs` and `socketcan_bridge` dependencies
- build and install new `odrive_can_node` executable

## Testing
- `colcon build --packages-select industrial_robot_jazzy` *(fails: Could not find a package configuration file provided by "ament_cmake")*

------
https://chatgpt.com/codex/tasks/task_e_689dd6224ce4832fa4f54b47791093b4