### PR TITLE
Use gz for Gazebo simulation

### DIFF
--- a/src/industrial_robot_jazzy/launch/gazebo_simulation.launch.py
+++ b/src/industrial_robot_jazzy/launch/gazebo_simulation.launch.py
@@ -1,68 +1,68 @@
 import os
-from ament_index_python.packages import get_package_share_directory
+
 from launch import LaunchDescription
-from launch.actions import DeclareLaunchArgument, ExecuteProcess, RegisterEventHandler
+from launch.actions import ExecuteProcess, RegisterEventHandler
 from launch.event_handlers import OnProcessExit
-from launch.substitutions import LaunchConfiguration, Command, FindExecutable, PathJoinSubstitution
+from launch.substitutions import Command, FindExecutable, PathJoinSubstitution
 from launch_ros.actions import Node
 from launch_ros.substitutions import FindPackageShare
 
+
 def generate_launch_description():
-    
-    # Package directories
-    pkg_share = FindPackageShare('industrial_robot_jazzy').find('industrial_robot_jazzy')
-    
+    """Create a launch description for simulating the robot with Gazebo (gz)."""
+
+    pkg_share = FindPackageShare("industrial_robot_jazzy").find("industrial_robot_jazzy")
+
     # Paths
-    urdf_file = os.path.join(pkg_share, 'urdf', 'robot.urdf.xacro')
-    controllers_file = os.path.join(pkg_share, 'config', 'controllers.yaml')
-    
-    # Get URDF via xacro
+    urdf_file = os.path.join(pkg_share, "urdf", "robot.urdf.xacro")
+    controllers_file = os.path.join(pkg_share, "config", "controllers.yaml")
+
+    # Generate robot description from xacro
     robot_description_content = Command(
         [
             PathJoinSubstitution([FindExecutable(name="xacro")]),
             " ",
-            PathJoinSubstitution([FindPackageShare("industrial_robot_jazzy"), "urdf", "robot.urdf.xacro"])
+            PathJoinSubstitution([FindPackageShare("industrial_robot_jazzy"), "urdf", "robot.urdf.xacro"]),
         ]
     )
-    
     robot_description = {"robot_description": robot_description_content}
-    
-    # Gazebo launch
+
+    # Gazebo (gz) simulator
     gazebo = ExecuteProcess(
-        cmd=['gazebo', '--verbose', '-s', 'libgazebo_ros_init.so', '-s', 'libgazebo_ros_factory.so'],
-        output='screen'
+        cmd=["gz", "sim", "-v", "4"],
+        output="screen",
     )
-    
-    # Robot State Publisher
+
+    # Publish robot state
     robot_state_publisher = Node(
         package="robot_state_publisher",
         executable="robot_state_publisher",
         output="both",
         parameters=[robot_description],
     )
-    
-    # Spawn robot
+
+    # Spawn robot into gz
     spawn_entity = Node(
-        package="gazebo_ros",
-        executable="spawn_entity.py",
-        arguments=["-topic", "robot_description", "-entity", "industrial_robot"],
+        package="ros_gz_sim",
+        executable="create",
+        arguments=["-name", "industrial_robot", "-topic", "robot_description"],
         output="screen",
     )
-    
+
     # Joint State Broadcaster
     joint_state_broadcaster_spawner = Node(
         package="controller_manager",
         executable="spawner",
         arguments=["joint_state_broadcaster", "--controller-manager", "/controller_manager"],
     )
-    
+
     # Position Controller
     position_controller_spawner = Node(
         package="controller_manager",
         executable="spawner",
         arguments=["position_controller", "--controller-manager", "/controller_manager"],
     )
-    
+
     # Delayed start for controllers
     delay_joint_state_broadcaster = RegisterEventHandler(
         event_handler=OnProcessExit(
@@ -70,18 +70,21 @@ def generate_launch_description():
             on_exit=[joint_state_broadcaster_spawner],
         )
     )
-    
+
     delay_position_controller = RegisterEventHandler(
         event_handler=OnProcessExit(
             target_action=joint_state_broadcaster_spawner,
             on_exit=[position_controller_spawner],
         )
     )
-    
-    return LaunchDescription([
-        gazebo,
-        robot_state_publisher,
-        spawn_entity,
-        delay_joint_state_broadcaster,
-        delay_position_controller,
-    ])
+
+    return LaunchDescription(
+        [
+            gazebo,
+            robot_state_publisher,
+            spawn_entity,
+            delay_joint_state_broadcaster,
+            delay_position_controller,
+        ]
+    )
+


### PR DESCRIPTION
## Summary
- replace Gazebo Classic invocation with `gz sim`
- switch spawning to use `ros_gz_sim` integration

## Testing
- `colcon test --packages-select industrial_robot_jazzy` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689ddcafc5e0832f947c2553d6f2b1df