### PR TITLE
Update Gazebo launch for gz

### DIFF
--- a/install/industrial_robot_jazzy/share/industrial_robot_jazzy/launch/gazebo_simulation.launch.py
+++ b/install/industrial_robot_jazzy/share/industrial_robot_jazzy/launch/gazebo_simulation.launch.py
@@ -1,68 +1,75 @@
 import os
-from ament_index_python.packages import get_package_share_directory
+
 from launch import LaunchDescription
-from launch.actions import DeclareLaunchArgument, ExecuteProcess, RegisterEventHandler
+from launch.actions import ExecuteProcess, RegisterEventHandler
 from launch.event_handlers import OnProcessExit
-from launch.substitutions import LaunchConfiguration, Command, FindExecutable, PathJoinSubstitution
+from launch.substitutions import Command, FindExecutable, PathJoinSubstitution
 from launch_ros.actions import Node
 from launch_ros.substitutions import FindPackageShare
 
+
 def generate_launch_description():
-    
-    # Package directories
-    pkg_share = FindPackageShare('industrial_robot_jazzy').find('industrial_robot_jazzy')
-    
+    """Create a launch description for simulating the robot with Gazebo (gz)."""
+
+    pkg_share = FindPackageShare("industrial_robot_jazzy").find("industrial_robot_jazzy")
+
     # Paths
-    urdf_file = os.path.join(pkg_share, 'urdf', 'robot.urdf.xacro')
-    controllers_file = os.path.join(pkg_share, 'config', 'controllers.yaml')
-    
-    # Get URDF via xacro
+    controllers_file = os.path.join(pkg_share, "config", "controllers.yaml")
+
+    # Generate robot description from xacro
     robot_description_content = Command(
         [
             PathJoinSubstitution([FindExecutable(name="xacro")]),
             " ",
-            PathJoinSubstitution([FindPackageShare("industrial_robot_jazzy"), "urdf", "robot.urdf.xacro"])
+            PathJoinSubstitution([FindPackageShare("industrial_robot_jazzy"), "urdf", "robot.urdf.xacro"]),
         ]
     )
-    
     robot_description = {"robot_description": robot_description_content}
-    
-    # Gazebo launch
+
+    # Gazebo (gz) simulator
     gazebo = ExecuteProcess(
-        cmd=['gazebo', '--verbose', '-s', 'libgazebo_ros_init.so', '-s', 'libgazebo_ros_factory.so'],
-        output='screen'
+        cmd=["gz", "sim", "-v", "4"],
+        output="screen",
     )
-    
-    # Robot State Publisher
+
+    # Robot description publisher
     robot_state_publisher = Node(
         package="robot_state_publisher",
         executable="robot_state_publisher",
         output="both",
         parameters=[robot_description],
     )
-    
-    # Spawn robot
-    spawn_entity = Node(
-        package="gazebo_ros",
-        executable="spawn_entity.py",
-        arguments=["-topic", "robot_description", "-entity", "industrial_robot"],
+
+    # ros2_control controller manager
+    ros2_control_node = Node(
+        package="controller_manager",
+        executable="ros2_control_node",
+        parameters=[robot_description, controllers_file],
         output="screen",
     )
-    
+
+    # Spawn robot into gz
+    spawn_entity = Node(
+        package="ros_gz_sim",
+        executable="create",
+        arguments=["-name", "industrial_robot", "-topic", "robot_description"],
+        output="screen",
+    )
+
     # Joint State Broadcaster
     joint_state_broadcaster_spawner = Node(
         package="controller_manager",
         executable="spawner",
         arguments=["joint_state_broadcaster", "--controller-manager", "/controller_manager"],
     )
-    
+
     # Position Controller
     position_controller_spawner = Node(
         package="controller_manager",
         executable="spawner",
         arguments=["position_controller", "--controller-manager", "/controller_manager"],
     )
-    
+
     # Delayed start for controllers
     delay_joint_state_broadcaster = RegisterEventHandler(
         event_handler=OnProcessExit(
@@ -70,18 +77,22 @@ def generate_launch_description():
             on_exit=[joint_state_broadcaster_spawner],
         )
     )
-    
+
     delay_position_controller = RegisterEventHandler(
         event_handler=OnProcessExit(
             target_action=joint_state_broadcaster_spawner,
             on_exit=[position_controller_spawner],
         )
     )
-    
-    return LaunchDescription([
-        gazebo,
-        robot_state_publisher,
-        spawn_entity,
-        delay_joint_state_broadcaster,
-        delay_position_controller,
-    ])
+
+    return LaunchDescription(
+        [
+            gazebo,
+            ros2_control_node,
+            robot_state_publisher,
+            spawn_entity,
+            delay_joint_state_broadcaster,
+            delay_position_controller,
+        ]
+    )
+

--- a/install/industrial_robot_jazzy/share/industrial_robot_jazzy/package.xml
+++ b/install/industrial_robot_jazzy/share/industrial_robot_jazzy/package.xml
@@ -17,11 +17,10 @@
   <depend>robot_state_publisher</depend>
   <depend>joint_state_publisher</depend>
   <depend>joint_state_publisher_gui</depend>
-  <depend>gazebo_ros</depend>
-  <depend>gazebo_ros_pkgs</depend>
+  <depend>ros_gz_sim</depend>
+  <depend>ros_gz_bridge</depend>
   <depend>ros2_control</depend>
   <depend>ros2_controllers</depend>
-  <depend>gazebo_ros2_control</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/src/industrial_robot_jazzy/launch/gazebo_simulation.launch.py
+++ b/src/industrial_robot_jazzy/launch/gazebo_simulation.launch.py
@@ -14,7 +14,6 @@ def generate_launch_description():
     pkg_share = FindPackageShare("industrial_robot_jazzy").find("industrial_robot_jazzy")
 
     # Paths
-    urdf_file = os.path.join(pkg_share, "urdf", "robot.urdf.xacro")
     controllers_file = os.path.join(pkg_share, "config", "controllers.yaml")
 
     # Generate robot description from xacro
@@ -33,12 +32,20 @@ def generate_launch_description():
         output="screen",
     )
 
-    # Publish robot state
+    # Robot description publisher
     robot_state_publisher = Node(
         package="robot_state_publisher",
         executable="robot_state_publisher",
         output="both",
         parameters=[robot_description],
+    )
+
+    # ros2_control controller manager
+    ros2_control_node = Node(
+        package="controller_manager",
+        executable="ros2_control_node",
+        parameters=[robot_description, controllers_file],
+        output="screen",
     )
 
     # Spawn robot into gz
@@ -81,6 +88,7 @@ def generate_launch_description():
     return LaunchDescription(
         [
             gazebo,
+            ros2_control_node,
             robot_state_publisher,
             spawn_entity,
             delay_joint_state_broadcaster,

--- a/src/industrial_robot_jazzy/package.xml
+++ b/src/industrial_robot_jazzy/package.xml
@@ -14,11 +14,10 @@
   <depend>robot_state_publisher</depend>
   <depend>joint_state_publisher</depend>
   <depend>joint_state_publisher_gui</depend>
-  <depend>gazebo_ros</depend>
-  <depend>gazebo_ros_pkgs</depend>
+  <depend>ros_gz_sim</depend>
+  <depend>ros_gz_bridge</depend>
   <depend>ros2_control</depend>
   <depend>ros2_controllers</depend>
-  <depend>gazebo_ros2_control</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>


### PR DESCRIPTION
## Summary
- switch Gazebo launch to use `gz sim` and add `ros2_control_node`
- depend on `ros_gz_sim` and `ros_gz_bridge`
- sync installed launch/package files

## Testing
- `python -m py_compile src/industrial_robot_jazzy/launch/gazebo_simulation.launch.py install/industrial_robot_jazzy/share/industrial_robot_jazzy/launch/gazebo_simulation.launch.py`
- `xmllint --noout src/industrial_robot_jazzy/package.xml install/industrial_robot_jazzy/share/industrial_robot_jazzy/package.xml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689de43d4b40832f89b50ccfcde90b3e