### PR TITLE
Add CAN communication node for ODrive

### DIFF
--- a/src/industrial_robot_jazzy/CMakeLists.txt
+++ b/src/industrial_robot_jazzy/CMakeLists.txt
@@ -8,6 +8,7 @@ endif()
 # find dependencies
 find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)
+find_package(rclpy REQUIRED)
 find_package(std_msgs REQUIRED)
 find_package(sensor_msgs REQUIRED)
 find_package(geometry_msgs REQUIRED)
@@ -29,6 +30,11 @@ ament_target_dependencies(robot_controller
 
 # Install executable
 install(TARGETS robot_controller
+  DESTINATION lib/${PROJECT_NAME}
+)
+
+# Install Python nodes
+install(PROGRAMS scripts/odrive_can.py
   DESTINATION lib/${PROJECT_NAME}
 )
 

--- a/src/industrial_robot_jazzy/launch/simple_robot.launch.py
+++ b/src/industrial_robot_jazzy/launch/simple_robot.launch.py
@@ -32,4 +32,11 @@ def generate_launch_description():
         output="screen",
     )
 
-    return LaunchDescription([rsp, jsp, rviz])
+    odrive_can = Node(
+        package="industrial_robot_jazzy",
+        executable="odrive_can.py",
+        name="odrive_can",
+        output="screen",
+    )
+
+    return LaunchDescription([rsp, jsp, rviz, odrive_can])

--- a/src/industrial_robot_jazzy/package.xml
+++ b/src/industrial_robot_jazzy/package.xml
@@ -10,6 +10,7 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
 
   <depend>rclcpp</depend>
+  <depend>rclpy</depend>
   <depend>std_msgs</depend>
   <depend>sensor_msgs</depend>
   <depend>geometry_msgs</depend>
@@ -22,6 +23,8 @@
   <depend>ros2_control</depend>
   <depend>ros2_controllers</depend>
   <depend>gazebo_ros2_control</depend>
+
+  <exec_depend>python3-can</exec_depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/src/industrial_robot_jazzy/scripts/odrive_can.py
+++ b/src/industrial_robot_jazzy/scripts/odrive_can.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+import rclpy
+from rclpy.node import Node
+import can
+
+
+class ODriveCANNode(Node):
+    """Simple node that communicates with an ODrive over CAN."""
+
+    def __init__(self):
+        super().__init__('odrive_can_node')
+        try:
+            self.bus = can.ThreadSafeBus('can0', bustype='socketcan')
+        except can.CanError as exc:
+            self.get_logger().error(f'Failed to connect to CAN bus: {exc}')
+            raise
+
+        self.get_logger().info('ODrive CAN node started')
+        self.timer = self.create_timer(1.0, self.send_commands)
+        self.notifier = can.Notifier(self.bus, [self.receive_message])
+
+    def send_commands(self):
+        """Send periodic control and status request frames."""
+        # Enter closed-loop control
+        try:
+            msg = can.Message(arbitration_id=0x207,
+                              data=[0x07, 0x00, 0x00, 0x00],
+                              is_extended_id=False)
+            self.bus.send(msg)
+        except can.CanError as exc:
+            self.get_logger().error(f'Failed to send control frame: {exc}')
+
+        # Request encoder estimates (remote frame)
+        try:
+            req = can.Message(arbitration_id=0x009,
+                              is_extended_id=False,
+                              is_remote_frame=True,
+                              dlc=8)
+            self.bus.send(req)
+        except can.CanError as exc:
+            self.get_logger().error(f'Failed to request status: {exc}')
+
+    def receive_message(self, msg: can.Message):
+        """Handle incoming CAN frames."""
+        if msg.arbitration_id == 0x009 and not msg.is_remote_frame:
+            pos = int.from_bytes(msg.data[0:4], byteorder='little', signed=True) / 100000.0
+            vel = int.from_bytes(msg.data[4:8], byteorder='little', signed=True) / 100000.0
+            self.get_logger().info(f'Pos: {pos:.2f}, Vel: {vel:.2f}')
+        else:
+            self.get_logger().debug(f'Received CAN frame: {msg}')
+
+
+def main():
+    rclpy.init()
+    node = ODriveCANNode()
+    try:
+        rclpy.spin(node)
+    finally:
+        node.destroy_node()
+        rclpy.shutdown()
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add Python node for communicating with ODrive v3.6 over CAN
- launch ODrive CAN node with simple_robot launch file
- register rclpy and python-can dependencies

## Testing
- `python -m py_compile src/industrial_robot_jazzy/scripts/odrive_can.py`
- `colcon build --packages-select industrial_robot_jazzy` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689df683d8cc832fae7a3754b806d789