### PR TITLE
Add RViz interface for ODrive calibration and parameter tuning

### DIFF
--- a/src/industrial_robot_jazzy/CMakeLists.txt
+++ b/src/industrial_robot_jazzy/CMakeLists.txt
@@ -13,6 +13,8 @@ find_package(std_msgs REQUIRED)
 find_package(sensor_msgs REQUIRED)
 find_package(geometry_msgs REQUIRED)
 find_package(trajectory_msgs REQUIRED)
+find_package(interactive_markers REQUIRED)
+find_package(visualization_msgs REQUIRED)
 
 # Create executable
 add_executable(robot_controller 
@@ -37,6 +39,9 @@ install(TARGETS robot_controller
 install(PROGRAMS scripts/odrive_can.py
   DESTINATION lib/${PROJECT_NAME}
 )
+install(PROGRAMS scripts/odrive_rviz_interface.py
+  DESTINATION lib/${PROJECT_NAME}
+)
 
 # Install launch files and other resources
 install(DIRECTORY launch
@@ -53,7 +58,7 @@ install(DIRECTORY config
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
-  ament_lint_auto_find_test_dependencies()
+ament_lint_auto_find_test_dependencies()
 endif()
 
 ament_package()

--- a/src/industrial_robot_jazzy/package.xml
+++ b/src/industrial_robot_jazzy/package.xml
@@ -15,6 +15,8 @@
   <depend>sensor_msgs</depend>
   <depend>geometry_msgs</depend>
   <depend>trajectory_msgs</depend>
+  <depend>interactive_markers</depend>
+  <depend>visualization_msgs</depend>
   <depend>robot_state_publisher</depend>
   <depend>joint_state_publisher</depend>
   <depend>joint_state_publisher_gui</depend>

--- a/src/industrial_robot_jazzy/scripts/odrive_can.py
+++ b/src/industrial_robot_jazzy/scripts/odrive_can.py
@@ -2,6 +2,7 @@
 import rclpy
 from rclpy.node import Node
 import can
+from std_msgs.msg import Bool, Float32
 
 
 class ODriveCANNode(Node):
@@ -18,6 +19,14 @@ class ODriveCANNode(Node):
         self.get_logger().info('ODrive CAN node started')
         self.timer = self.create_timer(1.0, self.send_commands)
         self.notifier = can.Notifier(self.bus, [self.receive_message])
+        self.create_subscription(Bool,
+                                 'odrive/calibrate_offset',
+                                 self.calibrate_offset_callback,
+                                 10)
+        self.create_subscription(Float32,
+                                 'odrive/vel_limit',
+                                 self.vel_limit_callback,
+                                 10)
 
     def send_commands(self):
         """Send periodic control and status request frames."""
@@ -48,6 +57,32 @@ class ODriveCANNode(Node):
             self.get_logger().info(f'Pos: {pos:.2f}, Vel: {vel:.2f}')
         else:
             self.get_logger().debug(f'Received CAN frame: {msg}')
+
+    def calibrate_offset_callback(self, msg: Bool):
+        """Request offset calibration when True is received."""
+        if not msg.data:
+            return
+        try:
+            frame = can.Message(arbitration_id=0x207,
+                                data=[0x03, 0x00, 0x00, 0x00],
+                                is_extended_id=False)
+            self.bus.send(frame)
+            self.get_logger().info('Calibration command sent')
+        except can.CanError as exc:
+            self.get_logger().error(f'Calibration command failed: {exc}')
+
+    def vel_limit_callback(self, msg: Float32):
+        """Set the ODrive velocity limit."""
+        vel = int(msg.data * 1000)
+        data = vel.to_bytes(4, 'little', signed=True) + (0).to_bytes(4, 'little', signed=True)
+        try:
+            frame = can.Message(arbitration_id=0x00B,
+                                data=data,
+                                is_extended_id=False)
+            self.bus.send(frame)
+            self.get_logger().info(f'Set velocity limit to {msg.data}')
+        except can.CanError as exc:
+            self.get_logger().error(f'Failed to set velocity limit: {exc}')
 
 
 def main():

--- a/src/industrial_robot_jazzy/scripts/odrive_rviz_interface.py
+++ b/src/industrial_robot_jazzy/scripts/odrive_rviz_interface.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+import rclpy
+from rclpy.node import Node
+from interactive_markers.interactive_marker_server import InteractiveMarkerServer
+from interactive_markers.menu_handler import MenuHandler
+from visualization_msgs.msg import InteractiveMarker, InteractiveMarkerControl, Marker
+from std_msgs.msg import Bool, Float32
+
+
+class ODriveRvizInterface(Node):
+    """Interactive marker interface to control ODrive from RViz."""
+
+    def __init__(self):
+        super().__init__('odrive_rviz_interface')
+        self.server = InteractiveMarkerServer(self, 'odrive_controls')
+        self.menu_handler = MenuHandler()
+        self.calib_pub = self.create_publisher(Bool, 'odrive/calibrate_offset', 10)
+        self.vel_pub = self.create_publisher(Float32, 'odrive/vel_limit', 10)
+
+        self._init_menu()
+        self._create_marker()
+        self.server.applyChanges()
+
+    def _init_menu(self):
+        self.menu_handler.insert('Calibrate Offset', callback=self._calibrate_cb)
+        vel_menu = self.menu_handler.insert('Velocity Limit')
+        for value in [5.0, 10.0]:
+            self.menu_handler.insert(f'{value} rad/s', parent=vel_menu,
+                                     callback=self._make_vel_cb(value))
+
+    def _create_marker(self):
+        int_marker = InteractiveMarker()
+        int_marker.header.frame_id = 'base_link'
+        int_marker.name = 'odrive_control'
+        int_marker.description = 'ODrive Control'
+
+        control = InteractiveMarkerControl()
+        control.interaction_mode = InteractiveMarkerControl.BUTTON
+        control.name = 'button'
+
+        marker = Marker()
+        marker.type = Marker.CUBE
+        marker.scale.x = marker.scale.y = marker.scale.z = 0.1
+        marker.color.g = 1.0
+        marker.color.a = 1.0
+
+        control.markers.append(marker)
+        control.always_visible = True
+        int_marker.controls.append(control)
+
+        self.server.insert(int_marker)
+        self.menu_handler.apply(self.server, int_marker.name)
+
+    def _calibrate_cb(self, feedback):
+        self.get_logger().info('Offset calibration requested')
+        self.calib_pub.publish(Bool(data=True))
+
+    def _make_vel_cb(self, value):
+        def cb(feedback):
+            self.get_logger().info(f'Setting velocity limit to {value}')
+            self.vel_pub.publish(Float32(data=value))
+        return cb
+
+
+def main():
+    rclpy.init()
+    node = ODriveRvizInterface()
+    try:
+        rclpy.spin(node)
+    finally:
+        node.destroy_node()
+        rclpy.shutdown()
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add interactive marker based RViz node to trigger ODrive calibration and adjust velocity limits
- extend ODrive CAN node with topics for calibration and velocity limit commands
- include new script and dependencies in build configuration

## Testing
- `colcon build --packages-select industrial_robot_jazzy` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689e21c9b198832fb8a638e9f2eae6e4